### PR TITLE
[Feat] add heat-cool, supported by Nest Thermostat

### DIFF
--- a/src/const.js
+++ b/src/const.js
@@ -6,6 +6,7 @@ const ICON = {
   HEAT: 'mdi:weather-sunny',
   AUTO: 'mdi:cached',
   COOL: 'mdi:snowflake',
+  HEAT_COOL: 'mdi:sun-snowflake',
   DRY: 'mdi:water',
   FAN_ONLY: 'mdi:fan',
   TOGGLE: 'mdi:dots-horizontal',


### PR DESCRIPTION
My Nest Thermostat is usually on heat-cool which currently has no icon