### PR TITLE
fix icons not showing in new HA version

### DIFF
--- a/src/components/button.js
+++ b/src/components/button.js
@@ -42,6 +42,7 @@ class ClimateButton extends LitElement {
          @click=${e => this.handleToggle(e)}
          ?disabled="${this.button.disabled || this.button.isUnavailable}"
          ?color=${this._isOn}>
+           <ha-icon .icon=${this.button.icon}></ha-icon>
         </ha-icon-button>
     `;
   }

--- a/src/components/dropdown-base.js
+++ b/src/components/dropdown-base.js
@@ -43,6 +43,7 @@ class ClimateDropdownBase extends LitElement {
           .icon=${this.icon}
           ?disabled=${this.disabled}
           ?color=${this.active}>
+            <ha-icon .icon=${this.icon}></ha-icon>
         </ha-icon-button>
         <paper-listbox slot="dropdown-content" .selected=${this.selectedId} @iron-select=${this.onChange}>
           ${this.items.map(item => html`

--- a/src/components/target-temperature.js
+++ b/src/components/target-temperature.js
@@ -68,10 +68,12 @@ class ClimateTargetTemperature extends LitElement {
         <ha-icon-button class='temp --up'
           .icon=${this.targetTemperature.icons.up}
           @click=${e => this.increment(e)}>
+          <ha-icon .icon=${this.targetTemperature.icons.up}></ha-icon>
         </ha-icon-button>
         <ha-icon-button class='temp --down'
           .icon=${this.targetTemperature.icons.down}
           @click=${e => this.decrement(e)}>
+           <ha-icon .icon=${this.targetTemperature.icons.down}></ha-icon>
         </ha-icon-button>
       </div>
     `;

--- a/src/main.js
+++ b/src/main.js
@@ -562,6 +562,7 @@ class MiniClimate extends LitElement {
         <ha-icon-button class='toggle-button ${this.toggleButtonCls()}'
           .icon=${this.config.toggle.icon}
           @click=${e => this.handleToggle(e)}>
+            <ha-icon .icon=${this.config.toggle.icon}></ha-icon>
         </ha-icon-button>
     `;
   }


### PR DESCRIPTION
Breaking changes made in the new HA version in the `ha-icon-button` element, causes the buttons to not show up. This PR fixed that issue while maintaining backward compatibility. I tested it locally on my hass instance.
You can see the change here:

https://github.com/home-assistant/frontend/blob/master/src/components/ha-icon-button.ts#L10-L11

https://github.com/home-assistant/frontend/commit/0c940be5fb002f7df938055997d2be71d6e50903#diff-b7749fac30d4d29a769a04d77d9e72093cfdfecd6e325fba66649575229bde9c
