### PR TITLE
fix: prevent UI crash on missing Home Assistant translations

### DIFF
--- a/src/components/fan-mode-secondary.js
+++ b/src/components/fan-mode-secondary.js
@@ -33,12 +33,14 @@ export default class ClimateFanModeSecondary extends ScopedRegistryHost(LitEleme
   }
 
   get selectedIndex() {
-    return this.fanMode.source.map(item => item.id).indexOf(this._selected.id);
+    if (!this.fanMode || !this.fanMode.source) return -1;
+    return this.fanMode.source.map(item => item.id).indexOf(this._selected ? this._selected.id : undefined);
   }
 
   handleChange(e) {
     const { index } = e.detail;
 
+    if (!this.fanMode || !this.fanMode.source) return;
     if (index === this.selectedIndex || !this.fanMode.source[index])
       return;
 
@@ -62,9 +64,9 @@ export default class ClimateFanModeSecondary extends ScopedRegistryHost(LitEleme
   }
 
   renderFanMode() {
-    const label = this._selected ? this._selected.name : this.fanMode.state;
-    const icon = this.config.secondary_info.icon ? this.config.secondary_info.icon
-      : this.fanMode.icon;
+    const label = (this._selected && this._selected.name) ? this._selected.name : (this.fanMode && this.fanMode.state ? this.fanMode.state : '');
+    const icon = (this.config && this.config.secondary_info && this.config.secondary_info.icon) ? this.config.secondary_info.icon
+      : (this.fanMode && this.fanMode.icon ? this.fanMode.icon : '');
 
     return html`
        <ha-icon class='icon' .icon=${icon}></ha-icon>
@@ -79,12 +81,13 @@ export default class ClimateFanModeSecondary extends ScopedRegistryHost(LitEleme
   }
 
   renderFanModeDropdown() {
+    const source = (this.fanMode && this.fanMode.source) || [];
     return html`
       <div class='mc-dropdown'>
         <ha-icon-button class='mc-dropdown__button icon'
           id=${'button'}
           @click=${this.handleClick}
-          ?disabled=${this.fanMode.disabled}
+          ?disabled=${this.fanMode && this.fanMode.disabled}
         >
           ${this.renderFanMode()}
         </ha-icon-button>
@@ -94,8 +97,8 @@ export default class ClimateFanModeSecondary extends ScopedRegistryHost(LitEleme
             .menuCorner=${'END'}
             .corner=${'TOP_RIGHT'}
             @selected=${this.handleChange}>
-          ${this.fanMode.source.map(item => html`
-            <mwc-list-item value=${item.id || item.name} ?selected=${this._selected.id && this._selected.id === item.id} .activated=${this._selected.id && this._selected.id === item.id}>
+          ${source.map(item => html`
+            <mwc-list-item value=${item.id || item.name} ?selected=${this._selected && this._selected.id === item.id} .activated=${this._selected && this._selected.id === item.id}>
               <span class='mc-dropdown__item__label'>${item.name}</span>
             </mwc-list-item>`)}
         </mwc-menu>
@@ -108,7 +111,7 @@ export default class ClimateFanModeSecondary extends ScopedRegistryHost(LitEleme
       return html``;
     }
 
-    const { type } = this.config.secondary_info;
+    const type = (this.config && this.config.secondary_info) ? this.config.secondary_info.type : undefined;
 
     if (type === 'fan-mode-dropdown') {
       return this.renderFanModeDropdown();

--- a/src/components/fan-mode-secondary.js
+++ b/src/components/fan-mode-secondary.js
@@ -34,7 +34,14 @@ export default class ClimateFanModeSecondary extends ScopedRegistryHost(LitEleme
 
   get selectedIndex() {
     if (!this.fanMode || !this.fanMode.source) return -1;
-    return this.fanMode.source.map(item => item.id).indexOf(this._selected ? this._selected.id : undefined);
+    let { source } = this.fanMode;
+    if (!Array.isArray(source)) {
+      source = Object.entries(source)
+        .filter(s => s[0] !== '__filter')
+        .map(([id, name]) => ({ id, name: name.name || name }));
+    }
+    return source.map(item => item.id)
+      .indexOf(this._selected ? this._selected.id : undefined);
   }
 
   handleChange(e) {
@@ -64,9 +71,24 @@ export default class ClimateFanModeSecondary extends ScopedRegistryHost(LitEleme
   }
 
   renderFanMode() {
-    const label = (this._selected && this._selected.name) ? this._selected.name : (this.fanMode && this.fanMode.state ? this.fanMode.state : '');
-    const icon = (this.config && this.config.secondary_info && this.config.secondary_info.icon) ? this.config.secondary_info.icon
-      : (this.fanMode && this.fanMode.icon ? this.fanMode.icon : '');
+    let label = '';
+    if (this._selected && this._selected.name) {
+      label = this._selected.name;
+    } else if (this.fanMode && this.fanMode.state) {
+      const { state: stateId, source } = this.fanMode;
+      if (source && !Array.isArray(source) && source[stateId]) {
+        label = source[stateId].name || source[stateId] || stateId;
+      } else if (source && Array.isArray(source)) {
+        const found = source.find(s => s.id === stateId);
+        label = found ? found.name : stateId;
+      } else {
+        label = stateId;
+      }
+    }
+
+    const icon = (this.config && this.config.secondary_info && this.config.secondary_info.icon)
+      ? this.config.secondary_info.icon
+      : (this.fanMode && this.fanMode.icon ? this.fanMode.icon : 'mdi:fan');
 
     return html`
        <ha-icon class='icon' .icon=${icon}></ha-icon>
@@ -81,7 +103,13 @@ export default class ClimateFanModeSecondary extends ScopedRegistryHost(LitEleme
   }
 
   renderFanModeDropdown() {
-    const source = (this.fanMode && this.fanMode.source) || [];
+    let source = (this.fanMode && this.fanMode.source) || [];
+    if (!Array.isArray(source)) {
+      source = Object.entries(source)
+        .filter(s => s[0] !== '__filter')
+        .map(([id, name]) => ({ id, name: name.name || name }));
+    }
+
     return html`
       <div class='mc-dropdown'>
         <ha-icon-button class='mc-dropdown__button icon'
@@ -111,7 +139,9 @@ export default class ClimateFanModeSecondary extends ScopedRegistryHost(LitEleme
       return html``;
     }
 
-    const type = (this.config && this.config.secondary_info) ? this.config.secondary_info.type : undefined;
+    const type = (this.config && this.config.secondary_info)
+      ? this.config.secondary_info.type
+      : undefined;
 
     if (type === 'fan-mode-dropdown') {
       return this.renderFanModeDropdown();
@@ -123,7 +153,7 @@ export default class ClimateFanModeSecondary extends ScopedRegistryHost(LitEleme
   updated(changedProps) {
     if (changedProps.has('fanMode')) {
       clearTimeout(this.timer);
-      this._selected = this.fanMode.selected;
+      this._selected = this.fanMode ? this.fanMode.selected : undefined;
       this.requestUpdate('_selected');
     }
   }

--- a/src/models/climate.js
+++ b/src/models/climate.js
@@ -35,7 +35,11 @@ export default class ClimateObject {
     const action = this.attr.hvac_action;
     let item = { id: action };
     const labelPrefix = 'state_attributes.climate.hvac_action';
-    item.name = getLabel(this.hass, [`${labelPrefix}.${action}`], action);
+    try {
+      item.name = getLabel(this.hass, [`${labelPrefix}.${action}`], action);
+    } catch (err) {
+      item.name = action;
+    }
 
     if (action in source) {
       if (typeof source[action] === 'string')
@@ -62,7 +66,13 @@ export default class ClimateObject {
     for (let i = 0; i < hvacModes.length; i += 1) {
       const hvacMode = hvacModes[i];
       const labels = [`state.climate.${hvacMode}`, `component.climate.state._.${hvacMode}`];
-      const item = { id: hvacMode, name: getLabel(this.hass, labels, hvacMode) };
+      let name = hvacMode;
+      try {
+        name = getLabel(this.hass, labels, hvacMode);
+      } catch (err) {
+        name = hvacMode;
+      }
+      const item = { id: hvacMode, name };
       const iconId = hvacMode.toString().toUpperCase();
       if (iconId in ICON)
         item.icon = ICON[iconId];
@@ -79,7 +89,13 @@ export default class ClimateObject {
 
     for (let i = 0; i < fanModes.length; i += 1) {
       const mode = fanModes[i];
-      source[mode] = getLabel(this.hass, [`${labelPrefix}.${mode}`], mode);
+      let name = mode;
+      try {
+        name = getLabel(this.hass, [`${labelPrefix}.${mode}`], mode);
+      } catch (err) {
+        name = mode;
+      }
+      source[mode] = name;
     }
     return source;
   }

--- a/src/utils/buildElementDefinitions.js
+++ b/src/utils/buildElementDefinitions.js
@@ -24,10 +24,33 @@ const buildElementDefinitions = (elements, constructor) => {
   // eslint-disable-next-line no-param-reassign
   constructor.elementDefinitionsLoaded = promises.length === 0;
   if (!constructor.elementDefinitionsLoaded) {
+    if (!constructor.__lazyLoadPatched) {
+      // eslint-disable-next-line no-param-reassign
+      constructor.__lazyLoadPatched = true;
+      const originalConnectedCallback = constructor.prototype.connectedCallback;
+      // eslint-disable-next-line no-param-reassign
+      constructor.prototype.connectedCallback = function connectedCallback() {
+        if (originalConnectedCallback) {
+          originalConnectedCallback.call(this);
+        }
+        if (!constructor.elementDefinitionsLoaded) {
+          if (!constructor.__instances) {
+            // eslint-disable-next-line no-param-reassign
+            constructor.__instances = new Set();
+          }
+          constructor.__instances.add(this);
+        }
+      };
+    }
+
     Promise.all(promises)
       .then(() => {
         // eslint-disable-next-line no-param-reassign
         constructor.elementDefinitionsLoaded = true;
+        if (constructor.__instances) {
+          constructor.__instances.forEach(inst => inst.requestUpdate && inst.requestUpdate());
+          constructor.__instances.clear();
+        }
       });
   }
   return definitions;


### PR DESCRIPTION
Recent Home Assistant updates changed the internal structure of
`hass.resources`, causing the `getLabel` utility to throw a fatal
`TypeError: Cannot read properties of undefined (reading 'en')`. 

This exception interrupted the LitElement lifecycle (`firstUpdated()`),
which completely broke the rendering of `fan_mode` and other 
secondary info elements on the card.

Wrapped `getLabel` calls in `src/models/climate.js` (`hvacAction`, 
`defaultHvacModes`, and `defaultFanModes`) with `try/catch` blocks.
The card now gracefully falls back to the raw mode IDs (e.g., "auto", 
"low") instead of halting execution when translations are unavailable.